### PR TITLE
2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ## [2.6.0] - 2017-09-16
 ### Added
-- Ensure latest pip is installed
+- Ensure latest `pip` is installed
 - Added support for `vmware_desktop` provider
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial stable release
 
-[Unreleased]: https://github.com/phalcon/box/compare/v2.5.2...development
+[Unreleased]: https://github.com/phalcon/box/compare/v2.6.0...development
+[2.6.0]: https://github.com/phalcon/box/compare/v2.5.2...v2.6.0
 [2.5.2]: https://github.com/phalcon/box/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/phalcon/box/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/phalcon/box/compare/v2.4.0...v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-## Changed
-- Set the minimal version of Ansible to be supported to `2.0`
-- Fixed ansible deprecation warnings
 
 ## [2.6.0] - 2017-09-16
 ### Added
@@ -15,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for `vmware_desktop` provider
 
 ### Changed
+- Set the minimal version of Ansible to be supported to `2.0`
+- Fixed ansible deprecation warnings
 - Bump minimal Vagrant Box version. See Maker changes:
   - [maker#2.1.0](https://github.com/phalcon/maker/releases/tag/v2.1.0)
   - [maker#2.1.1](https://github.com/phalcon/maker/releases/tag/v2.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - [maker#2.1.0](https://github.com/phalcon/maker/releases/tag/v2.1.0)
   - [maker#2.1.1](https://github.com/phalcon/maker/releases/tag/v2.1.1)
 
-### Fixeds
+### Fixed
 - Making compatible boxes. See [VMX Whitelisting](https://www.vagrantup.com/docs/vmware/boxes.html#vmx-whitelisting)
 
 ## [2.5.2] - 2017-09-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Changed
+- Set the minimal version of Ansible to be supported to `2.0`
+- Fixed ansible deprecation warnings
+
 ## [2.6.0] - 2017-09-16
 ### Added
 - Ensure latest `pip` is installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [2.6.0] - 2017-09-16
+### Added
+- Ensure latest pip is installed
+
+### Changed
+- Bump minimal Vagrant Box version. See Maker changes:
+  - [maker#2.1.0](https://github.com/phalcon/maker/releases/tag/v2.1.0)
+  - [maker#2.1.1](https://github.com/phalcon/maker/releases/tag/v2.1.1)
 
 ## [2.5.2] - 2017-09-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.6.0] - 2017-09-16
 ### Added
 - Ensure latest pip is installed
+- Added support for `vmware_desktop` provider
 
 ### Changed
 - Bump minimal Vagrant Box version. See Maker changes:
   - [maker#2.1.0](https://github.com/phalcon/maker/releases/tag/v2.1.0)
   - [maker#2.1.1](https://github.com/phalcon/maker/releases/tag/v2.1.1)
+
+### Fixeds
+- Making compatible boxes. See [VMX Whitelisting](https://www.vagrantup.com/docs/vmware/boxes.html#vmx-whitelisting)
 
 ## [2.5.2] - 2017-09-16
 ### Fixed

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 New BSD License
 
-Copyright (c) 2011-2017, Phalcon Framework Team
+Copyright (c) 2011-present, Phalcon Framework Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/provisioning/include/apt.yml
+++ b/provisioning/include/apt.yml
@@ -1,5 +1,5 @@
 ---
-  # See: https://github.com/ansible/ansible-modules-core/issues/3523
+# See: https://github.com/ansible/ansible-modules-core/issues/3523
 - name: Ensure aptitude is installed
   raw: apt-get install aptitude -y
   when: (settings.provision is defined) and (settings.provision.update is defined) and settings.provision.update

--- a/provisioning/include/apt.yml
+++ b/provisioning/include/apt.yml
@@ -1,5 +1,5 @@
 ---
-# See: https://github.com/ansible/ansible-modules-core/issues/3523
+# Workaround for ansible/ansible-modules-core#3523
 - name: Ensure aptitude is installed
   raw: apt-get install aptitude -y
   when: (settings.provision is defined) and (settings.provision.update is defined) and settings.provision.update

--- a/provisioning/include/initial.yml
+++ b/provisioning/include/initial.yml
@@ -1,3 +1,3 @@
 ---
 - name: Ensure latest pip is installed
-    raw: pip install --upgrade pip
+  raw: pip install --upgrade pip

--- a/provisioning/include/initial.yml
+++ b/provisioning/include/initial.yml
@@ -1,4 +1,3 @@
 ---
-
 - name: Ensure latest pip is installed
     raw: pip install --upgrade pip

--- a/provisioning/include/initial.yml
+++ b/provisioning/include/initial.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Ensure latest pip is installed
+    raw: pip install --upgrade pip

--- a/provisioning/main.yml
+++ b/provisioning/main.yml
@@ -4,16 +4,16 @@
   gather_facts: yes
 
   tasks:
-    - include: include/initial.yml
-    - include: include/certificates.yml
-    - include: include/apt.yml
-    - include: include/blackfire.yml
-    - include: include/php-fpm.yml
-    - include: include/nginx.yml
-    - include: include/aliases.yml
-    - include: include/dotfiles.yml
-    - include: include/mysql.yml
-    - include: include/postgresql.yml
-    - include: include/mongo.yml
-    - include: include/composer.yml
-    - include: include/motd.yml
+    - import_tasks: include/initial.yml
+    - import_tasks: include/certificates.yml
+    - import_tasks: include/apt.yml
+    - import_tasks: include/blackfire.yml
+    - import_tasks: include/php-fpm.yml
+    - import_tasks: include/nginx.yml
+    - import_tasks: include/aliases.yml
+    - import_tasks: include/dotfiles.yml
+    - import_tasks: include/mysql.yml
+    - import_tasks: include/postgresql.yml
+    - import_tasks: include/mongo.yml
+    - import_tasks: include/composer.yml
+    - import_tasks: include/motd.yml

--- a/provisioning/main.yml
+++ b/provisioning/main.yml
@@ -4,6 +4,7 @@
   gather_facts: yes
 
   tasks:
+    - include: include/initial.yml
     - include: include/certificates.yml
     - include: include/apt.yml
     - include: include/blackfire.yml

--- a/src/phalcon.rb
+++ b/src/phalcon.rb
@@ -15,7 +15,7 @@ require_relative 'files'
 
 # The main Phalcon Box class
 class Phalcon
-  VERSION = '2.5.3'.freeze
+  VERSION = '2.6.0'.freeze
 
   attr_accessor :config, :settings
 

--- a/src/phalcon.rb
+++ b/src/phalcon.rb
@@ -15,7 +15,7 @@ require_relative 'files'
 
 # The main Phalcon Box class
 class Phalcon
-  VERSION = '2.5.2'.freeze
+  VERSION = '2.5.3'.freeze
 
   attr_accessor :config, :settings
 

--- a/src/phalcon.rb
+++ b/src/phalcon.rb
@@ -53,6 +53,7 @@ class Phalcon
       ansible.limit = :all
       ansible.extra_vars = { settings: settings }
       ansible.verbose = settings[:verbose]
+      ansible.compatibility_mode = '2.0'
     end
 
     return unless Vagrant.has_plugin? 'vagrant-hostsupdater'

--- a/src/settings.rb
+++ b/src/settings.rb
@@ -7,7 +7,7 @@ require_relative 'prober'
 # Initialize user settings
 class Settings
   DEFAULT_IP = '192.168.50.4'
-  BOX_VERSION = '2.0.3'
+  BOX_VERSION = '2.1.1'
   DEFAULT_CPUS = 2
   DEFAULT_MEMORY = 2048
 
@@ -42,9 +42,6 @@ class Settings
     @settings = DEFAULT_SETTINGS.merge(load_file)
 
     setup_provision
-
-    # puts settings[:provision].inspect
-    # abort
 
     memory = setup_memory
     memory = 1024 if memory.to_i < 1024

--- a/src/vmware.rb
+++ b/src/vmware.rb
@@ -11,7 +11,7 @@ class VMWare
   end
 
   def configure
-    %i(vmware_fusion vmware_workstation).each do |vmware|
+    %i(vmware_desktop vmware_fusion vmware_workstation).each do |vmware|
       customize vmware
     end
   end
@@ -22,6 +22,7 @@ class VMWare
       v.vmx['memsize'] = settings[:memory]
       v.vmx['numvcpus'] = settings[:cpus]
       v.vmx['guestOS'] = 'ubuntu-64'
+      v.whitelist_verified = true
       v.gui = true if settings[:gui]
     end
   end


### PR DESCRIPTION
### Added
- Ensure latest `pip` is installed
- Added support for `vmware_desktop` provider

### Changed
- Set the minimal version of Ansible to be supported to `2.0`
- Fixed ansible deprecation warnings
- Bump minimal Vagrant Box version. See Maker changes:
  - [maker#2.1.0](https://github.com/phalcon/maker/releases/tag/v2.1.0)
  - [maker#2.1.1](https://github.com/phalcon/maker/releases/tag/v2.1.1)

### Fixed
- Making compatible boxes. See [VMX Whitelisting](https://www.vagrantup.com/docs/vmware/boxes.html#vmx-whitelisting)
